### PR TITLE
Additional board configuration. Basic PIO LED Control.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,40 +1,56 @@
 # GP2040 - Multi-platform Gamepad Firmware for RP2040 microcontrollers
 
-The goal of GP2040 is to provide multi-platform compatibility for RP2040-based game controllers. GP2040 currently support XInput on PC, Android, Raspberry Pi and others along with native Nintendo Switch compatibility. It also features such a 1ms response time, Left/Right stick emulation via D-pad and SOCD (Simultaneous Opposite Cardinal Direction) cleaning for the DIY fightstick crowd.
+The goal of GP2040 is to provide multi-platform compatibility for RP2040-based game controllers.
+
+## Features
+
+* XInput (PC, Android, Raspberry Pi, etc.) and Nintendo Switch support
+* Left and Right stick emulation via D-pad inputs
+* 3 SOCD cleaning modes - Neutral, Up Priority (a.k.a. Hitbox), Second Input Priority
+* Low input latency, with default 1000 Hz (1 ms) polling rate in all modes
+* Save options to internal memory
 
 ## Performance
 
-Input latency is tested using the methodology outlined at [WydD's outstanding inputlag.science website](https://inputlag.science/controller/methodology), using the default 1000Hz (1ms) polling rate in the firmware.
+One of the highest priorities of GP2040 is low input latency. Why bother building a custom controller if it's just a laggy, input-missing mess?
 
-| Mode | Min | Max | Avg | Stdev | % on time | %1f skip | %2f skip |
-| - | - | - | - | - | - | - | - |
-| XInput (1ms polling) | 0.56 ms | 1.34 ms | 0.86 ms | 0.24 ms | 95.94% | 4.06% | 0% |
+Input latency is tested using the methodology outlined at [WydD's inputlag.science website](https://inputlag.science/controller/methodology), using the default 1000 Hz (1 ms) polling rate in the firmware.
 
-## Building/Customization
+| Mode | Poll Rate | Min | Max | Avg | Stdev | % on time | %1f skip | %2f skip |
+| - | - | - | - | - | - | - | - | - |
+| XInput | 1 ms | 0.56 ms | 1.34 ms | 0.86 ms | 0.24 ms | 95.94% | 4.06% | 0% |
+| Switch | 1 ms | 0.56 ms | 1.34 ms | 0.86 ms | 0.24 ms | 95.89% | 4.11% | 0% |
 
-The project is built using the PlatformIO VS Code plugin along with the [Wiz-IO Raspberry Pi Pico](https://github.com/Wiz-IO/wizio-pico) platform package using the baremetal configuration. There are no external dependencies outside of the Pico SDK included in the Wiz-IO platform.
+## Development
 
-### Edit Existing Definition
+The project is built using the PlatformIO VS Code plugin along with the [Wiz-IO Raspberry Pi Pico](https://github.com/Wiz-IO/wizio-pico) platform package, using the Wiz-IO baremetal (Pico SDK) configuration. Only the Pico SDK is utilized, so there are no external dependencies at this time.
 
-Once you have the project loaded into PlatformIO, edit the `include/definitions/RP2040Board.h` file to map your GPIO pins. Then from the PlatformIO environment selector, choose `env:raspberry-pi-pico`. From there you should be able to build or upload the project to you RP2040 board.
+There are two simple options for building GP2040 for your board. You can either edit an existing board definition, or create your own and configure PlatformIO to build it.
 
-### Create New Definition
+### Edit Definition
+
+Once you have the project loaded into PlatformIO, edit the `include/definitions/RP2040Board.h` file to map your GPIO pins. Then from the VS Code status bar, use the PlatformIO environment selector to choose `env:raspberry-pi-pico`.
+
+### Create Definition
 
 You can also add a new board definition to `include/definitions`. If you do, perform the following:
 
-* Add `#define` for it in `include/definitions/BoardConfig.h`.
+* Create new board definition file in `include/definitions` with your pin configuration and options.
+* Add `#define` for your new board in `include/definitions/BoardConfig.h`.
 * Add option to `src/RP2040Gamepad.cpp` in the `BOARD_DEFINITION` selection logic.
 * Add a new environment to the `platformio.ini`
-  * Copy from existing env
+  * Copy from existing environment and rename
   * Replace `BOARD_DEFINITION=#` with the number in the `BoardConfig.h` file.
 
-You will now have a new build environment target for PlatformIO.
+You will now have a new build environment target for PlatformIO. Use the VS Code status bar to select your new environment target.
+
+### Building the Project
+
+You should now be able to build or upload the project to you RP2040 board from the Build and Upload status bar icons. You can also open the PlatformIO tab and select the actions to execute for a particular environment. Output folders are defined in the `platformio.ini` file, but they should all default to a path under `.pio/build/${env:NAME}`.
 
 ## Usage
 
-### Layout
-
-The project uses a generic button labeling for gamepad state, which is then converted to the appropriate input type before sending. Here are the mappings of generic buttons to each supported platform/layout:
+GP2040 uses a generic button labeling for gamepad state, which is then converted to the appropriate input type before sending. Here are the mappings of generic buttons to each supported platform/layout:
 
 | Generic | XInput | Switch  | Arcade |
 | ------- | ------ | ------- | ------ |
@@ -57,7 +73,7 @@ Any references to these buttons will use the `XInput` labels in this documentati
 
 ### Home Button
 
-If you do not have a dedicated Home button, but you can activate it via the **`BACK + START + UP`** button combination.
+If you do not have a dedicated Home button, you can activate it via the **`BACK + START + UP`** button combination.
 
 ### Input Modes
 
@@ -90,6 +106,7 @@ SOCD mode is saved across power cycles.
 
 ## Acknowledgements
 
-* Ha Thach for the TinyUSB library and excellent examples.
-* fluffymadness for the [tinyusb-xinput](https://github.com/fluffymadness/tinyusb-xinput) example.
-* Kevin Boone for his [blog post on using RP2040 flash memory as emulated EEPROM](https://kevinboone.me/picoflash.html).
+* Ha Thach's excellent [TinyUSB library](https://github.com/hathach/tinyusb) examples
+* Thomas Fredericks' [Bounce2 Arduino library](https://github.com/thomasfredericks/Bounce2)
+* fluffymadness's [tinyusb-xinput](https://github.com/fluffymadness/tinyusb-xinput) sample
+* Kevin Boone's [blog post on using RP2040 flash memory as emulated EEPROM](https://kevinboone.me/picoflash.html)

--- a/lib/Gamepad/include/Gamepad.h
+++ b/lib/Gamepad/include/Gamepad.h
@@ -208,49 +208,49 @@ class GamepadClass
 
 			switch (dpad & (GAMEPAD_MASK_UP | GAMEPAD_MASK_DOWN))
 			{
-			case (GAMEPAD_MASK_UP | GAMEPAD_MASK_DOWN):
-				if (mode == SOCD_MODE_UP_PRIORITY)
-				{
+				case (GAMEPAD_MASK_UP | GAMEPAD_MASK_DOWN):
+					if (mode == SOCD_MODE_UP_PRIORITY)
+					{
+						new_dpad |= GAMEPAD_MASK_UP;
+						last_ud = DIRECTION_UP;
+					}
+					else if (mode == SOCD_MODE_SECOND_INPUT_PRIORITY && last_ud != DIRECTION_NONE)
+						new_dpad |= (last_ud == DIRECTION_UP) ? GAMEPAD_MASK_DOWN : GAMEPAD_MASK_UP;
+					else
+						last_ud = DIRECTION_NONE;
+					break;
+				case GAMEPAD_MASK_UP:
 					new_dpad |= GAMEPAD_MASK_UP;
 					last_ud = DIRECTION_UP;
-				}
-				else if (mode == SOCD_MODE_SECOND_INPUT_PRIORITY && last_ud != DIRECTION_NONE)
-					new_dpad |= (last_ud == DIRECTION_UP) ? GAMEPAD_MASK_DOWN : GAMEPAD_MASK_UP;
-				else
+					break;
+				case GAMEPAD_MASK_DOWN:
+					new_dpad |= GAMEPAD_MASK_DOWN;
+					last_ud = DIRECTION_DOWN;
+					break;
+				default:
 					last_ud = DIRECTION_NONE;
-				break;
-			case GAMEPAD_MASK_UP:
-				new_dpad |= GAMEPAD_MASK_UP;
-				last_ud = DIRECTION_UP;
-				break;
-			case GAMEPAD_MASK_DOWN:
-				new_dpad |= GAMEPAD_MASK_DOWN;
-				last_ud = DIRECTION_DOWN;
-				break;
-			default:
-				last_ud = DIRECTION_NONE;
-				break;
-			}
+					break;
+				}
 
-			switch (dpad & (GAMEPAD_MASK_LEFT | GAMEPAD_MASK_RIGHT))
-			{
-			case (GAMEPAD_MASK_LEFT | GAMEPAD_MASK_RIGHT):
-				if (mode == SOCD_MODE_SECOND_INPUT_PRIORITY && last_lr != DIRECTION_NONE)
-					new_dpad |= (last_lr == DIRECTION_LEFT) ? GAMEPAD_MASK_RIGHT : GAMEPAD_MASK_LEFT;
-				else
+				switch (dpad & (GAMEPAD_MASK_LEFT | GAMEPAD_MASK_RIGHT))
+				{
+				case (GAMEPAD_MASK_LEFT | GAMEPAD_MASK_RIGHT):
+					if (mode == SOCD_MODE_SECOND_INPUT_PRIORITY && last_lr != DIRECTION_NONE)
+						new_dpad |= (last_lr == DIRECTION_LEFT) ? GAMEPAD_MASK_RIGHT : GAMEPAD_MASK_LEFT;
+					else
+						last_lr = DIRECTION_NONE;
+					break;
+				case GAMEPAD_MASK_LEFT:
+					new_dpad |= GAMEPAD_MASK_LEFT;
+					last_lr = DIRECTION_LEFT;
+					break;
+				case GAMEPAD_MASK_RIGHT:
+					new_dpad |= GAMEPAD_MASK_RIGHT;
+					last_lr = DIRECTION_RIGHT;
+					break;
+				default:
 					last_lr = DIRECTION_NONE;
-				break;
-			case GAMEPAD_MASK_LEFT:
-				new_dpad |= GAMEPAD_MASK_LEFT;
-				last_lr = DIRECTION_LEFT;
-				break;
-			case GAMEPAD_MASK_RIGHT:
-				new_dpad |= GAMEPAD_MASK_RIGHT;
-				last_lr = DIRECTION_RIGHT;
-				break;
-			default:
-				last_lr = DIRECTION_NONE;
-				break;
+					break;
 			}
 
 			return new_dpad;

--- a/lib/Gamepad/include/GamepadDebouncer.h
+++ b/lib/Gamepad/include/GamepadDebouncer.h
@@ -1,7 +1,8 @@
 /* 
  * SPDX-License-Identifier: MIT
  * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
- *
+ * SPDX-FileCopyrightText: Copyright (c) 2013 thomasfredericks
+ * 
  * Debouncer class ported from the Arduino Bounce2 library (MIT license).
  */
 

--- a/lib/Gamepad/src/GamepadDebouncer.cpp
+++ b/lib/Gamepad/src/GamepadDebouncer.cpp
@@ -1,6 +1,7 @@
 /* 
  * SPDX-License-Identifier: MIT
  * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2013 thomasfredericks
  *
  * Debouncer class ported from the Arduino Bounce2 library (MIT license).
  */

--- a/lib/TinyUSB_Gamepad/include/xinput_device.h
+++ b/lib/TinyUSB_Gamepad/include/xinput_device.h
@@ -62,75 +62,75 @@ static const char *xinput_string_descriptors[] =
 
 static const uint8_t xinput_device_descriptor[] =
 {
-	0x12,				// bLength
-	0x01,				// bDescriptorType (Device)
+	0x12,       // bLength
+	0x01,       // bDescriptorType (Device)
 	0x00, 0x02, // bcdUSB 2.00
-	0xFF,				// bDeviceClass
-	0xFF,				// bDeviceSubClass
-	0xFF,				// bDeviceProtocol
-	0x40,				// bMaxPacketSize0 64
+	0xFF,	      // bDeviceClass
+	0xFF,	      // bDeviceSubClass
+	0xFF,	      // bDeviceProtocol
+	0x40,	      // bMaxPacketSize0 64
 	0x5E, 0x04, // idVendor 0x045E
 	0x8E, 0x02, // idProduct 0x028E
 	0x14, 0x01, // bcdDevice 2.14
-	0x01,				// iManufacturer (String Index)
-	0x02,				// iProduct (String Index)
-	0x03,				// iSerialNumber (String Index)
-	0x01				// bNumConfigurations 1
+	0x01,       // iManufacturer (String Index)
+	0x02,       // iProduct (String Index)
+	0x03,       // iSerialNumber (String Index)
+	0x01,       // bNumConfigurations 1
 };
 
 static const uint8_t xinput_configuration_descriptor[] =
 {
 	//Configuration Descriptor:
-	0x09,				// bLength
-	0x02,				// bDescriptorType
+	0x09,       // bLength
+	0x02,       // bDescriptorType
 	0x30, 0x00, // wTotalLength   (48 bytes)
-	0x01,				// bNumInterfaces
-	0x01,				// bConfigurationValue
-	0x00,				// iConfiguration
-	0x80,				// bmAttributes   (Bus-powered Device)
-	0xFA,				// bMaxPower      (500 mA)
+	0x01,       // bNumInterfaces
+	0x01,       // bConfigurationValue
+	0x00,       // iConfiguration
+	0x80,       // bmAttributes   (Bus-powered Device)
+	0xFA,       // bMaxPower      (500 mA)
 
 	//Interface Descriptor:
-	0x09, // bLength
-	0x04, // bDescriptorType
-	0x00, // bInterfaceNumber
-	0x00, // bAlternateSetting
-	0x02, // bNumEndPoints
-	0xFF, // bInterfaceClass      (Vendor specific)
-	0x5D, // bInterfaceSubClass
-	0x01, // bInterfaceProtocol
-	0x00, // iInterface
+	0x09,       // bLength
+	0x04,       // bDescriptorType
+	0x00,       // bInterfaceNumber
+	0x00,       // bAlternateSetting
+	0x02,       // bNumEndPoints
+	0xFF,       // bInterfaceClass      (Vendor specific)
+	0x5D,       // bInterfaceSubClass
+	0x01,       // bInterfaceProtocol
+	0x00,       // iInterface
 
 	//Unknown HID Descriptor:
-	0x10,				// bLength
-	0x21,				// bDescriptorType (HID)
+	0x10,       // bLength
+	0x21,       // bDescriptorType (HID)
 	0x10, 0x01, // bcdHID 1.10
-	0x01,				// bCountryCode
-	0x24,				// bNumDescriptors
-	0x81,				// bDescriptorType[0] (Unknown 0x81)
+	0x01,	      // bCountryCode
+	0x24,	      // bNumDescriptors
+	0x81,	      // bDescriptorType[0] (Unknown 0x81)
 	0x14, 0x03, // wDescriptorLength[0] 788
-	0x00,				// bDescriptorType[1] (Unknown 0x00)
+	0x00,       // bDescriptorType[1] (Unknown 0x00)
 	0x03, 0x13, // wDescriptorLength[1] 4867
-	0x02,				// bDescriptorType[2] (Unknown 0x02)
+	0x02,       // bDescriptorType[2] (Unknown 0x02)
 	0x00, 0x03, // wDescriptorLength[2] 768
-	0x00,				// bDescriptorType[3] (Unknown 0x00)
+	0x00,       // bDescriptorType[3] (Unknown 0x00)
 
 	//Endpoint Descriptor:
-	0x07,				// bLength
-	0x05,				// bDescriptorType
-	0x81,				// bEndpointAddress  (IN endpoint 1)
-	0x03,				// bmAttributes      (Transfer: Interrupt / Synch: None / Usage: Data)
+	0x07,       // bLength
+	0x05,       // bDescriptorType
+	0x81,       // bEndpointAddress  (IN endpoint 1)
+	0x03,       // bmAttributes      (Transfer: Interrupt / Synch: None / Usage: Data)
 	0x20, 0x00, // wMaxPacketSize    (1 x 32 bytes)
 	// 0x04,       // bInterval         (4 frames)
-	0x01, // bInterval         (1 frames)
+	0x01,       // bInterval         (1 frames)
 
 	//Endpoint Descriptor:
-	0x07,				// bLength
-	0x05,				// bDescriptorType
-	0x02,				// bEndpointAddress  (OUT endpoint 2)
-	0x03,				// bmAttributes      (Transfer: Interrupt / Synch: None / Usage: Data)
+	0x07,       // bLength
+	0x05,       // bDescriptorType
+	0x02,       // bEndpointAddress  (OUT endpoint 2)
+	0x03,       // bmAttributes      (Transfer: Interrupt / Synch: None / Usage: Data)
 	0x20, 0x00, // wMaxPacketSize    (1 x 32 bytes)
-	0x08,				// bInterval         (8 frames)
+	0x08,       // bInterval         (8 frames)
 };
 
 #endif

--- a/lib/TinyUSB_Gamepad/src/tusb_driver.c
+++ b/lib/TinyUSB_Gamepad/src/tusb_driver.c
@@ -14,7 +14,6 @@
 #include "hid_driver.h"
 #include "xinput_driver.h"
 
-
 InputMode current_input_mode = XINPUT;
 
 void initialize_driver(void)

--- a/lib/TinyUSB_Gamepad/src/usb_descriptors.c
+++ b/lib/TinyUSB_Gamepad/src/usb_descriptors.c
@@ -1,6 +1,7 @@
 /*
  * SPDX-License-Identifier: MIT
  * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Ha Thach (tinyusb.org)
  */
 
 #include "tusb.h"
@@ -23,17 +24,13 @@ uint16_t const *tud_descriptor_string_cb(uint8_t index, uint16_t langid)
 	{
 		case XINPUT:
 			for (int i = 0; i < 4; i++)
-			{
 				string_descriptors[i] = xinput_string_descriptors[i];
-			}
 			break;
 
 		case SWITCH:
 		default:
 			for (int i = 0; i < 4; i++)
-			{
 				string_descriptors[i] = switch_string_descriptors[i];
-			}
 			break;
 	}
 

--- a/lib/TinyUSB_Gamepad/src/xinput_driver.c
+++ b/lib/TinyUSB_Gamepad/src/xinput_driver.c
@@ -25,17 +25,17 @@ bool send_xinput_report(void *report, uint8_t report_size)
 	return sent;
 }
 
-static void gamepad_init(void)
+static void xinput_init(void)
 {
 
 }
 
-static void gamepad_reset(uint8_t __unused rhport)
+static void xinput_reset(uint8_t __unused rhport)
 {
 
 }
 
-static uint16_t gamepad_open(uint8_t __unused rhport, tusb_desc_interface_t const *itf_descriptor, uint16_t max_length)
+static uint16_t xinput_open(uint8_t __unused rhport, tusb_desc_interface_t const *itf_descriptor, uint16_t max_length)
 {
 	uint16_t driver_length = sizeof(tusb_desc_interface_t)
 		+ (itf_descriptor->bNumEndpoints * sizeof(tusb_desc_endpoint_t))
@@ -65,17 +65,17 @@ static uint16_t gamepad_open(uint8_t __unused rhport, tusb_desc_interface_t cons
 	return driver_length;
 }
 
-static bool gamepad_device_control_request(uint8_t __unused rhport, tusb_control_request_t __unused const *request)
+static bool xinput_device_control_request(uint8_t __unused rhport, tusb_control_request_t __unused const *request)
 {
 	return true;
 }
 
-static bool gamepad_control_complete(uint8_t __unused rhport, tusb_control_request_t __unused const *request)
+static bool xinput_control_complete(uint8_t __unused rhport, tusb_control_request_t __unused const *request)
 {
 	return true;
 }
 
-static bool gamepad_xfer_callback(uint8_t __unused rhport, uint8_t __unused ep_addr, xfer_result_t __unused result, uint32_t __unused xferred_bytes)
+static bool xinput_xfer_callback(uint8_t __unused rhport, uint8_t __unused ep_addr, xfer_result_t __unused result, uint32_t __unused xferred_bytes)
 {
 	return true;
 }
@@ -85,11 +85,11 @@ const usbd_class_driver_t xinput_driver =
 #if CFG_TUSB_DEBUG >= 2
 	.name = "XINPUT",
 #endif
-	.init = gamepad_init,
-	.reset = gamepad_reset,
-	.open = gamepad_open,
-	.control_request = gamepad_device_control_request,
-	.control_complete = gamepad_control_complete,
-	.xfer_cb = gamepad_xfer_callback,
+	.init = xinput_init,
+	.reset = xinput_reset,
+	.open = xinput_open,
+	.control_request = xinput_device_control_request,
+	.control_complete = xinput_control_complete,
+	.xfer_cb = xinput_xfer_callback,
 	.sof = NULL
 };

--- a/src/RP2040Gamepad.cpp
+++ b/src/RP2040Gamepad.cpp
@@ -13,7 +13,7 @@
 #if BOARD_DEFINITION == DEBUG_BOARD
 #include "definitions/DebugBoard.h"
 #elif BOARD_DEFINITION == PICO_BOARD
-#include "definitions/RP2040Board.h""
+#include "definitions/RP2040Board.h"
 #elif BOARD_DEFINITION == OPEN_STICK_BOARD
 #include "definitions/OpenStickBoard.h"
 #elif BOARD_DEFINITION == TEST_BOARD
@@ -41,7 +41,7 @@ GamepadButtonMapping GamepadClass::mapButton14  = { .port = 0, .pin = PIN_BUTTON
 
 void GamepadClass::setup()
 {
-	static GamepadButtonMapping *gamepadMappings[] =
+	GamepadButtonMapping *gamepadMappings[] =
 	{
 		&mapDpadUp,   &mapDpadDown, &mapDpadLeft, &mapDpadRight,
 		&mapButton01, &mapButton02, &mapButton03, &mapButton04,

--- a/src/tusb_config.h
+++ b/src/tusb_config.h
@@ -1,8 +1,7 @@
 /*
  * SPDX-License-Identifier: MIT
  * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
- *
- * Adapted from example provided in the TinyUSB library (MIT license).
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Ha Thach (tinyusb.org)
  */
 
 #ifndef TUSB_CONFIG_H_


### PR DESCRIPTION
I've added optional configuration for default mode values so that they can be changed on a per board basis. I've also added optional LED support. It's very basic--blink the pressed button if LEDs are configured for that button--but it's enough to prove things out.

The LED setup has two (future) problems:

1. We're limited to a single LED per button. There are a number of things out there at the moment that have multiple per button. The big hold up is the inability to create an array with #defines, but I'm hesitant to start storing actual variables in the board configuration files. Open to suggestions here. TOML or something would be more muggle friendly, but it's a lot more work than just defining some constants.

2. It needs to be migrated out of main.cpp into somewhere we can easily manage the current state for animations. Button presses should be telling this class "hey man, animate this button" and not worrying about handling the actual animation.